### PR TITLE
fix temp switches

### DIFF
--- a/include/menus/any_saves_menu.h
+++ b/include/menus/any_saves_menu.h
@@ -1,6 +1,6 @@
 #include "menu.h"
 
-#define ANY_SPECIALS_AMNT 15
+#define ANY_SPECIALS_AMNT 17
 
 enum AnyPracticeIndex {
     ORDON_GATE_CLIP_INDEX,

--- a/include/menus/hundo_saves_menu.h
+++ b/include/menus/hundo_saves_menu.h
@@ -2,7 +2,7 @@
 
 #include "menu.h"
 
-#define HND_SPECIALS_AMNT 25
+#define HND_SPECIALS_AMNT 27
 
 enum HundoPracticeIndex {
     HND_GOATS_1_INDEX,

--- a/src/menus/any_saves_menu.cpp
+++ b/src/menus/any_saves_menu.cpp
@@ -104,9 +104,19 @@ void stallord() {
     tp_gameInfo.warp.entrance.spawn = 0x01;  // spawn at in front of stally
 }
 
+void fan_tower() {
+    SaveInjector::inject_default_during();
+    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0; // reset city switches
+}
+
 void argorok() {
     SaveInjector::inject_default_during();
     tp_gameInfo.boss_room_event_flags = 1;
+}
+
+void palace1() {
+    SaveInjector::inject_default_during();
+    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0; // reset palace switches
 }
 
 void palace2() {
@@ -148,7 +158,9 @@ void AnySavesMenu::render() {
         special(LAKEBED_1_INDEX, bossflags, nullptr),
         special(WATERFALL_SIDEHOP_INDEX, waterfall_sidehop, nullptr),
         special(DARK_HAMMER_INDEX, bossflags, darkhammer),
+        special(FAN_TOWER_INDEX, fan_tower, nullptr),
         special(ARGOROK_INDEX, argorok, nullptr),
+        special(PALACE_1_INDEX, palace1, nullptr),
         special(PALACE_2_INDEX, nullptr, palace2)};
 
     if (button_is_pressed(Controller::B)) {

--- a/src/menus/any_saves_menu.cpp
+++ b/src/menus/any_saves_menu.cpp
@@ -106,7 +106,7 @@ void stallord() {
 
 void fan_tower() {
     SaveInjector::inject_default_during();
-    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0; // reset city switches
+    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0;  // reset city switches
 }
 
 void argorok() {
@@ -116,7 +116,7 @@ void argorok() {
 
 void palace1() {
     SaveInjector::inject_default_during();
-    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0; // reset palace switches
+    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0;  // reset palace switches
 }
 
 void palace2() {

--- a/src/menus/dungeon_flags_menu.cpp
+++ b/src/menus/dungeon_flags_menu.cpp
@@ -40,7 +40,7 @@ Line lines[LINES] = {
     {"clear flags", CLEAR_DUNGEON_FLAGS_INDEX, "Clear all selected dungeon flags"}};
 
 void copyGlobalFlags(uint8_t id) {
-    if (tp_gameInfo.area_id == id) {
+    if (tp_gameInfo.dungeon_temp_flags.mStageNum == id) {
         for (uint8_t j = 0; j < 0x20; j++) {
             tp_gameInfo.temp_flags.flags[j] = dungeon_node->flags[j];
         }

--- a/src/menus/hundo_saves_menu.cpp
+++ b/src/menus/hundo_saves_menu.cpp
@@ -224,7 +224,7 @@ void cits_poe_cycle() {
 
 void fan_tower() {
     SaveInjector::inject_default_during();
-    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0; // reset city switches
+    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0;  // reset city switches
 }
 
 void argorok() {
@@ -234,7 +234,7 @@ void argorok() {
 
 void palace1() {
     SaveInjector::inject_default_during();
-    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0; // reset palace switches
+    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0;  // reset palace switches
 }
 
 void palace2() {
@@ -257,7 +257,7 @@ void bossflags() {
 
 void cave_of_ordeals() {
     SaveInjector::inject_default_during();
-    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0; // reset all CoO doors
+    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0;  // reset all CoO doors
 }
 
 void HundoSavesMenu::render() {

--- a/src/menus/hundo_saves_menu.cpp
+++ b/src/menus/hundo_saves_menu.cpp
@@ -222,9 +222,19 @@ void cits_poe_cycle() {
     set_angle_position();
 }
 
+void fan_tower() {
+    SaveInjector::inject_default_during();
+    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0; // reset city switches
+}
+
 void argorok() {
     SaveInjector::inject_default_during();
     tp_gameInfo.boss_room_event_flags = 1;
+}
+
+void palace1() {
+    SaveInjector::inject_default_during();
+    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0; // reset palace switches
 }
 
 void palace2() {
@@ -247,10 +257,7 @@ void bossflags() {
 
 void cave_of_ordeals() {
     SaveInjector::inject_default_during();
-    tp_gameInfo.floors.floor_01_08 = 0;  // reset all CoO doors on load
-    tp_gameInfo.floors.floor_09_17 = 0;
-    tp_gameInfo.floors.floor_18_26 = 0;
-    tp_gameInfo.floors.floor_27_34 = 0;
+    tp_gameInfo.dungeon_temp_flags.switch_bitfield[0] = 0; // reset all CoO doors
 }
 
 void HundoSavesMenu::render() {
@@ -274,7 +281,9 @@ void HundoSavesMenu::render() {
         special(HND_EARLY_HP_INDEX, tot_early_hp, nullptr),
         special(HND_CITY_EARLY_INDEX, hugo_archery, nullptr),
         special(HND_POE_CYCLE_INDEX, cits_poe_cycle, nullptr),
+        special(HND_FAN_TOWER_INDEX, fan_tower, nullptr),
         special(HND_ARGOROK_INDEX, argorok, nullptr),
+        special(HND_PALACE_1_INDEX, palace1, nullptr),
         special(HND_PALACE_2_INDEX, nullptr, palace2),
         special(HND_COO_INDEX, cave_of_ordeals, nullptr),
         special(HND_COO_10_INDEX, cave_of_ordeals, nullptr),

--- a/src/save_injector.cpp
+++ b/src/save_injector.cpp
@@ -9,7 +9,7 @@ namespace SaveInjector {
 // inject qlog bytes into RAM
 void inject_save(void* buffer) {
     tp_memcpy((void*)&tp_gameInfo, buffer, 2392);
-    tp_getSave(&tp_gameInfo, tp_gameInfo.area_id);
+    tp_getSave(&tp_gameInfo, tp_gameInfo.dungeon_temp_flags.mStageNum);
 };
 
 void inject_default_before() {


### PR DESCRIPTION
fixes city and palace temp switches when you already turned them on then reload fan tower or palace1. could be made a global reset, but wasnt sure if needed